### PR TITLE
Basic idea of db interface for PIR DBs

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,0 +1,27 @@
+package db
+
+// Generalized PIR database interface to be implemented
+// TODO: Determine concrete function signatures for this interface
+type PIRDB interface {
+	// Initialized the PIR database with some data
+	Init() error
+	// Updates the PIR database with new data
+	Update() error
+	// Removes data from the PIR database
+	Remove() error
+	// Gets data from the PIR database
+	RetrieveData() error
+	// Retrieves Manifest file for the DB
+	GetManifestFile() (*ManifestFile, error)
+}
+
+// Manifest file interface meant to be implemented as part of a PIRDB implementation
+// Manifest files are used to give PIR clients a view of a PIR server's database in order
+// properly query for their needed data.
+// TODO: Finalize function signatures
+type ManifestFile interface {
+	// Serializes a Manifest file into some desirable format
+	Serialize() (*byte, error)
+	Deserialize() (*byte, error)
+	OutputToFile() (*byte, error)
+}


### PR DESCRIPTION
I'm opening this draft PR to start a discussion on how to go about actually designing the interfaces that we think might be conducive to implementing scalable PIR protocols. The main goal is to allow PIR protocol implementers the ability to conform to the same set of interfaces while allowing them to plug and play with different implementations of DBs without being constrained to a single implementation. That way, an implementer who needs more complex features can implement those without breaking APIs. 

At the time of this PR being opened, there is only a `db.go` file that has the basic interfaces that I think is definitely needed towards these goals. I'm in the midst of providing a very basic implementation of a DB that implements these interfaces and maybe we can use that as a default for the other PIR protocols that we want to implement.